### PR TITLE
Fix problems building jasper and gdal

### DIFF
--- a/Postgres.xcodeproj/project.pbxproj
+++ b/Postgres.xcodeproj/project.pbxproj
@@ -7,11 +7,13 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		3609051B172147B6002FBC53 /* openssl */ = {
+		369B335E1757816A00FD18FE /* openssl */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 3609051E172147B6002FBC53 /* Build configuration list for PBXAggregateTarget "openssl" */;
+			buildConfigurationList = 369B33601757816A00FD18FE /* Build configuration list for PBXAggregateTarget "openssl" */;
 			buildPhases = (
-				3609051F172147C1002FBC53 /* ShellScript */,
+				369B335F1757816A00FD18FE /* Download OpenSSL */,
+				369B3363175781A400FD18FE /* Extract OpenSSL Sources */,
+				369B3364175781A600FD18FE /* Build OpenSSL */,
 			);
 			dependencies = (
 			);
@@ -22,7 +24,9 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = F802E6651730A780005EFEA5 /* Build configuration list for PBXAggregateTarget "libuuid" */;
 			buildPhases = (
-				F802E6661730A785005EFEA5 /* Download, Configure, and Install libuuid */,
+				36BC17EC1758AC5400567951 /* Dowload libuuid */,
+				36BC17ED1758AC5600567951 /* Extract sources */,
+				F802E6661730A785005EFEA5 /* Build libuuid */,
 			);
 			dependencies = (
 			);
@@ -33,7 +37,9 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = F802E66A1730AB6D005EFEA5 /* Build configuration list for PBXAggregateTarget "libxml2" */;
 			buildPhases = (
-				F802E66D1730AB76005EFEA5 /* Download, Configure, and Install libxml2 */,
+				36E814B217579EC800A993BF /* Download libxml2 */,
+				36BC17F01758BCD200567951 /* Extract libxml2 sources */,
+				F802E66D1730AB76005EFEA5 /* build libxml2 */,
 			);
 			dependencies = (
 			);
@@ -63,10 +69,15 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = F805350415388AE5000E1BAC /* Build configuration list for PBXAggregateTarget "postgresql" */;
 			buildPhases = (
-				F805351B15388B0A000E1BAC /* Download, Build, & Install postgres */,
+				36E814B01757971D00A993BF /* Download postgres */,
+				36E814B11757971F00A993BF /* Extract Sources */,
+				F805351B15388B0A000E1BAC /* Build & Install postgres */,
 			);
 			dependencies = (
-				36AEBA961721582D003B4CB9 /* PBXTargetDependency */,
+				36BC17EF1758AEDC00567951 /* PBXTargetDependency */,
+				36E814B51757A12E00A993BF /* PBXTargetDependency */,
+				367FC5AE1758885B00BD53A9 /* PBXTargetDependency */,
+				369B33661757906300FD18FE /* PBXTargetDependency */,
 			);
 			name = postgresql;
 			productName = postgres;
@@ -109,7 +120,9 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = F8273EF3156AC7B900199DA0 /* Build configuration list for PBXAggregateTarget "libedit" */;
 			buildPhases = (
-				F8273EF5156AC7C200199DA0 /* Download, Build, & Install libedit */,
+				F8273EF5156AC7C200199DA0 /* Download libedit */,
+				367FC5AB1758870900BD53A9 /* Extract Sources */,
+				367FC5AC1758870D00BD53A9 /* Build */,
 			);
 			dependencies = (
 			);
@@ -192,10 +205,8 @@
 		0710E97E1639ADD7006D7FB2 /* status-off@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0710E9791639ADD7006D7FB2 /* status-off@2x.png */; };
 		0710E97F1639ADD7006D7FB2 /* status-on@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0710E97B1639ADD7006D7FB2 /* status-on@2x.png */; };
 		0710E9801639ADD7006D7FB2 /* status-on@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0710E97B1639ADD7006D7FB2 /* status-on@2x.png */; };
-		F80534FB1538884E000E1BAC /* bin in Copy postgres Executables */ = {isa = PBXBuildFile; fileRef = F80534F31538884A000E1BAC /* bin */; };
-		F80534FC1538884E000E1BAC /* include in Copy postgres Executables */ = {isa = PBXBuildFile; fileRef = F80534F41538884A000E1BAC /* include */; };
-		F80534FD1538884E000E1BAC /* lib in Copy postgres Executables */ = {isa = PBXBuildFile; fileRef = F80534F51538884A000E1BAC /* lib */; };
-		F80534FE1538884E000E1BAC /* share in Copy postgres Executables */ = {isa = PBXBuildFile; fileRef = F80534F61538884A000E1BAC /* share */; };
+		F80534FC1538884E000E1BAC /* include in Copy include, share */ = {isa = PBXBuildFile; fileRef = F80534F41538884A000E1BAC /* include */; };
+		F80534FE1538884E000E1BAC /* share in Copy include, share */ = {isa = PBXBuildFile; fileRef = F80534F61538884A000E1BAC /* share */; };
 		F81386711538E586003A83F9 /* PostgresConnectionURLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = F81386701538E586003A83F9 /* PostgresConnectionURLValueTransformer.m */; };
 		F87A426F153AB60C00456130 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8973A0C1538846600EAB41E /* Cocoa.framework */; };
 		F87A4275153AB60C00456130 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F87A4273153AB60C00456130 /* InfoPlist.strings */; };
@@ -236,10 +247,8 @@
 		F8A4B50B15735C6E003C00F5 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = F8973A211538846600EAB41E /* MainMenu.xib */; };
 		F8A4B50D15735C6E003C00F5 /* PostgresStatusMenuItemView.xib in Resources */ = {isa = PBXBuildFile; fileRef = F884C904153C807400CDCB09 /* PostgresStatusMenuItemView.xib */; };
 		F8A4B50E15735C6E003C00F5 /* Postgres.icns in Resources */ = {isa = PBXBuildFile; fileRef = F884C919153CA24400CDCB09 /* Postgres.icns */; };
-		F8A4B51115735C6E003C00F5 /* bin in Copy postgres Executables */ = {isa = PBXBuildFile; fileRef = F80534F31538884A000E1BAC /* bin */; };
-		F8A4B51215735C6E003C00F5 /* include in Copy postgres Executables */ = {isa = PBXBuildFile; fileRef = F80534F41538884A000E1BAC /* include */; };
-		F8A4B51315735C6E003C00F5 /* lib in Copy postgres Executables */ = {isa = PBXBuildFile; fileRef = F80534F51538884A000E1BAC /* lib */; };
-		F8A4B51415735C6E003C00F5 /* share in Copy postgres Executables */ = {isa = PBXBuildFile; fileRef = F80534F61538884A000E1BAC /* share */; };
+		F8A4B51215735C6E003C00F5 /* include in Copy include, share */ = {isa = PBXBuildFile; fileRef = F80534F41538884A000E1BAC /* include */; };
+		F8A4B51415735C6E003C00F5 /* share in Copy include, share */ = {isa = PBXBuildFile; fileRef = F80534F61538884A000E1BAC /* share */; };
 		F8A4B51615735C6E003C00F5 /* com.heroku.postgres-service.xpc in Copy XPC Service */ = {isa = PBXBuildFile; fileRef = F8973A3C1538851D00EAB41E /* com.heroku.postgres-service.xpc */; };
 		F8A4B51815735C6E003C00F5 /* PostgresHelper.app in Copy Helper Application */ = {isa = PBXBuildFile; fileRef = F87A426D153AB60C00456130 /* PostgresHelper.app */; };
 		F8A4B56C15735F26003C00F5 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A4B56B15735F26003C00F5 /* Sparkle.framework */; };
@@ -251,12 +260,40 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		36AEBA951721582D003B4CB9 /* PBXContainerItemProxy */ = {
+		367FC5AD1758885B00BD53A9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F89739FF1538846600EAB41E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3609051B172147B6002FBC53;
+			remoteGlobalIDString = F8273EF0156AC7B900199DA0;
+			remoteInfo = libedit;
+		};
+		369B33651757906300FD18FE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F89739FF1538846600EAB41E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 369B335E1757816A00FD18FE;
 			remoteInfo = openssl;
+		};
+		36BC17EE1758AEDC00567951 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F89739FF1538846600EAB41E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F802E6621730A780005EFEA5;
+			remoteInfo = libuuid;
+		};
+		36BC17F31758D93C00567951 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F89739FF1538846600EAB41E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F805350315388AE4000E1BAC;
+			remoteInfo = postgresql;
+		};
+		36E814B41757A12E00A993BF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F89739FF1538846600EAB41E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F802E6691730AB6D005EFEA5;
+			remoteInfo = libxml2;
 		};
 		F802E6671730AACB005EFEA5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -366,18 +403,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		F80534EF15388783000E1BAC /* Copy postgres Executables */ = {
+		F80534EF15388783000E1BAC /* Copy include, share */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 6;
 			files = (
-				F80534FB1538884E000E1BAC /* bin in Copy postgres Executables */,
-				F80534FC1538884E000E1BAC /* include in Copy postgres Executables */,
-				F80534FD1538884E000E1BAC /* lib in Copy postgres Executables */,
-				F80534FE1538884E000E1BAC /* share in Copy postgres Executables */,
+				F80534FC1538884E000E1BAC /* include in Copy include, share */,
+				F80534FE1538884E000E1BAC /* share in Copy include, share */,
 			);
-			name = "Copy postgres Executables";
+			name = "Copy include, share";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F87A4287153AB65800456130 /* Copy Helper Application */ = {
@@ -402,18 +437,16 @@
 			name = "Copy XPC Service";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F8A4B51015735C6E003C00F5 /* Copy postgres Executables */ = {
+		F8A4B51015735C6E003C00F5 /* Copy include, share */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 6;
 			files = (
-				F8A4B51115735C6E003C00F5 /* bin in Copy postgres Executables */,
-				F8A4B51215735C6E003C00F5 /* include in Copy postgres Executables */,
-				F8A4B51315735C6E003C00F5 /* lib in Copy postgres Executables */,
-				F8A4B51415735C6E003C00F5 /* share in Copy postgres Executables */,
+				F8A4B51215735C6E003C00F5 /* include in Copy include, share */,
+				F8A4B51415735C6E003C00F5 /* share in Copy include, share */,
 			);
-			name = "Copy postgres Executables";
+			name = "Copy include, share";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F8A4B51515735C6E003C00F5 /* Copy XPC Service */ = {
@@ -724,6 +757,22 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXLegacyTarget section */
+		364C86591758E1F20088CA7A /* postgr */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "$(ACTION)";
+			buildConfigurationList = 364C865A1758E1F20088CA7A /* Build configuration list for PBXLegacyTarget "postgr" */;
+			buildPhases = (
+			);
+			buildToolPath = /usr/bin/make;
+			dependencies = (
+			);
+			name = postgr;
+			passBuildSettingsInEnvironment = 1;
+			productName = postgr;
+		};
+/* End PBXLegacyTarget section */
+
 /* Begin PBXNativeTarget section */
 		F87A426C153AB60C00456130 /* PostgresHelper */ = {
 			isa = PBXNativeTarget;
@@ -749,15 +798,17 @@
 				F8973A041538846600EAB41E /* Sources */,
 				F8973A051538846600EAB41E /* Frameworks */,
 				F8973A061538846600EAB41E /* Resources */,
-				F80534EF15388783000E1BAC /* Copy postgres Executables */,
 				F8973A51153885A100EAB41E /* Copy XPC Service */,
 				F87A4287153AB65800456130 /* Copy Helper Application */,
+				367FC5AA1757B53100BD53A9 /* Copy Executables & libraries, Fix dylib paths */,
+				F80534EF15388783000E1BAC /* Copy include, share */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				F8973A4C1538858900EAB41E /* PBXTargetDependency */,
 				F87A4286153AB65200456130 /* PBXTargetDependency */,
+				36BC17F41758D93C00567951 /* PBXTargetDependency */,
 			);
 			name = Postgres;
 			productName = Postgres;
@@ -791,7 +842,8 @@
 				F8A4B50915735C6E003C00F5 /* Resources */,
 				F8A4B51515735C6E003C00F5 /* Copy XPC Service */,
 				F8A4B51715735C6E003C00F5 /* Copy Helper Application */,
-				F8A4B51015735C6E003C00F5 /* Copy postgres Executables */,
+				36BC17F21758D7D300567951 /* Copy Executables & libraries, Fix dylib paths */,
+				F8A4B51015735C6E003C00F5 /* Copy include, share */,
 			);
 			buildRules = (
 			);
@@ -837,12 +889,13 @@
 				F802E6621730A780005EFEA5 /* libuuid */,
 				F802E6691730AB6D005EFEA5 /* libxml2 */,
 				F805350315388AE4000E1BAC /* postgresql */,
-				3609051B172147B6002FBC53 /* openssl */,
 				F805350715388AEC000E1BAC /* geos */,
 				F8B05E24153E43D900A8D53A /* gdal */,
 				F805350B15388AF0000E1BAC /* proj */,
 				F805350F15388AF3000E1BAC /* postgis */,
 				F8A544331566B85900997555 /* plv8 */,
+				369B335E1757816A00FD18FE /* openssl */,
+				364C86591758E1F20088CA7A /* postgr */,
 			);
 		};
 /* End PBXProject section */
@@ -900,46 +953,247 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3609051F172147C1002FBC53 /* ShellScript */ = {
+		367FC5AA1757B53100BD53A9 /* Copy Executables & libraries, Fix dylib paths */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Copy Executables & libraries, Fix dylib paths";
 			outputPaths = (
+				$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/bin/psql,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n\nmkdir -p ${PROJECT_DIR}/src\ncd ${PROJECT_DIR}/src\n\n# $OPENSSL_VERSION defined in Build Settings\n\n/usr/bin/curl --silent --show-error --remote-name \"http://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz\"\n/usr/bin/tar xzf \"openssl-${OPENSSL_VERSION}.tar.gz\"\n\ncd \"openssl-${OPENSSL_VERSION}\"\n\nsh ./Configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" darwin64-x86_64-cc zlib no-asm no-krb5 shared\n/usr/bin/make && /usr/bin/make install\n";
+			shellScript = "EXECUTABLE_TARGET_DIR=\"$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH\"\n\n# copy binaries\ncd \"${PROJECT_DIR}/Postgres/Vendor/postgres/bin/\"\nmkdir -p \"$EXECUTABLE_TARGET_DIR/bin/\"\ncp clusterdb createdb createlang createuser dropdb droplang dropuser ecpg initdb oid2name pg_archivecleanup pg_basebackup pg_config pg_controldata pg_ctl pg_dump pg_dumpall pg_receivexlog pg_resetxlog pg_restore pg_standby pg_test_fsync pg_test_timing pg_upgrade pgbench postgres postmaster psql reindexdb vacuumdb vacuumlo \"$EXECUTABLE_TARGET_DIR/bin/\"\n\n# copy dynamic libraries only (no need for static libraries)\ncd \"${PROJECT_DIR}/Postgres/Vendor/postgres/lib/\"\nmkdir -p \"$EXECUTABLE_TARGET_DIR/lib/\"\ncp -af *.dylib *.so \"$EXECUTABLE_TARGET_DIR/lib/\"\n\n# fix dylib paths\ncd \"$EXECUTABLE_TARGET_DIR\"\nprefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\"\nprefix_length=${#prefix}\n\n# fix library ids\nfor libfile in lib/*\ndo\n\tlibrary_id=$(otool -D $libfile | grep \"$prefix\");\n\tif [[ -n \"$library_id\" ]]\n\tthen\n        new_library_id=\"@loader_path/..\"${library_id:$prefix_length}\n        install_name_tool -id \"$new_library_id\" \"$libfile\"\n\tfi\ndone\n    \n# fix library references\nfor file in lib/* bin/*\ndo\n\tlinked_libs=$(otool -L $file | egrep --only-matching \"\\Q$prefix\\E\\S+\");\n\tfor lib_path in $linked_libs\n\tdo\n        new_lib_path=\"@loader_path/..\"${lib_path:$prefix_length}\n        install_name_tool -change \"$lib_path\" \"$new_lib_path\" $file\n\tdone\ndone";
 		};
-		F802E6661730A785005EFEA5 /* Download, Configure, and Install libuuid */ = {
+		367FC5AB1758870900BD53A9 /* Extract Sources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PROJECT_DIR}/src/libedit-${LIBEDIT_VERSION}.tar.gz",
 			);
-			name = "Download, Configure, and Install libuuid";
+			name = "Extract Sources";
 			outputPaths = (
+				"${PROJECT_DIR}/src/libedit-${LIBEDIT_VERSION}",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n\nmkdir -p ${PROJECT_DIR}/src\ncd ${PROJECT_DIR}/src\n\n# $LIBUUID_VERSION defined in Build Settings\n\n/usr/bin/curl -O \"http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-${LIBUUID_VERSION}.tar.gz\"\n/usr/bin/tar xzf \"uuid-${LIBUUID_VERSION}.tar.gz\"\n\ncd \"uuid-${LIBUUID_VERSION}\"\n\nsh ./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" --disable-debug\n/usr/bin/make\n/usr/bin/make install\n";
+			shellPath = /bin/bash;
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src\"\n/usr/bin/tar xzf \"libedit-${LIBEDIT_VERSION}.tar.gz\"";
 		};
-		F802E66D1730AB76005EFEA5 /* Download, Configure, and Install libxml2 */ = {
+		367FC5AC1758870D00BD53A9 /* Build */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/src/libedit-${LIBEDIT_VERSION}",
+			);
+			name = Build;
+			outputPaths = (
+				"${PROJECT_DIR}/Postgres/Vendor/postgres/lib/libedit.dylib",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src/libedit-${LIBEDIT_VERSION}\"\nsh ./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\"\n/usr/bin/make install";
+		};
+		369B335F1757816A00FD18FE /* Download OpenSSL */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Download, Configure, and Install libxml2";
+			name = "Download OpenSSL";
 			outputPaths = (
+				"${PROJECT_DIR}/src/openssl-${OPENSSL_VERSION}.tar.gz",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\n\nmkdir -p \"${PROJECT_DIR}/src\"\ncd \"${PROJECT_DIR}/src\"\n\n# $OPENSSL_VERSION defined in Build Settings\n/usr/bin/curl --silent --show-error --remote-name \"http://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz\"";
+			showEnvVarsInLog = 0;
+		};
+		369B3363175781A400FD18FE /* Extract OpenSSL Sources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/src/openssl-${OPENSSL_VERSION}.tar.gz",
+			);
+			name = "Extract OpenSSL Sources";
+			outputPaths = (
+				"${PROJECT_DIR}/src/openssl-${OPENSSL_VERSION}",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src\"\n/usr/bin/tar xzf \"openssl-${OPENSSL_VERSION}.tar.gz\"";
+			showEnvVarsInLog = 0;
+		};
+		369B3364175781A600FD18FE /* Build OpenSSL */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/src/openssl-${OPENSSL_VERSION}",
+			);
+			name = "Build OpenSSL";
+			outputPaths = (
+				"${PROJECT_DIR}/Postgres/Vendor/postgres/lib/libssl.dylib",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\n\ncd \"${PROJECT_DIR}/src/openssl-${OPENSSL_VERSION}\"\n\nsh ./Configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" darwin64-x86_64-cc zlib no-asm no-krb5 shared\n\n# disable some warnigs that we know will occur\nsed \"s/-Wall/-Wall -Wno-unused-value -Wno-sometimes-uninitialized/\" <Makefile >Makefile.fixed\nmv Makefile.fixed Makefile\n\n/usr/bin/make && /usr/bin/make install\n\ntouch ${PROJECT_DIR}/Postgres/Vendor/postgres/lib/libssl.dylib";
+			showEnvVarsInLog = 0;
+		};
+		36BC17EC1758AC5400567951 /* Dowload libuuid */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Dowload libuuid";
+			outputPaths = (
+				"${PROJECT_DIR}/src/uuid-${LIBUUID_VERSION}.tar.gz",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\nmkdir -p \"${PROJECT_DIR}/src\"\ncd \"${PROJECT_DIR}/src\"\n/usr/bin/curl --silent --show-error --remote-name \"http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-${LIBUUID_VERSION}.tar.gz\"";
+		};
+		36BC17ED1758AC5600567951 /* Extract sources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/src/uuid-${LIBUUID_VERSION}.tar.gz",
+			);
+			name = "Extract sources";
+			outputPaths = (
+				"${PROJECT_DIR}/src/uuid-${LIBUUID_VERSION}",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n\nmkdir -p ${PROJECT_DIR}/src\ncd ${PROJECT_DIR}/src\n\n# $LIBXML2_VERSION defined in Build Settings\n\n/usr/bin/curl -O \"ftp://xmlsoft.org/libxml2/libxml2-${LIBXML2_VERSION}.tar.gz\"\n/usr/bin/tar xzf \"libxml2-${LIBXML2_VERSION}.tar.gz\"\n\ncd libxml2-${LIBXML2_VERSION}\n\nsh ./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" --disable-dependency-tracking\n/usr/bin/make install";
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src\"\n/usr/bin/tar xzf \"uuid-${LIBUUID_VERSION}.tar.gz\"";
+		};
+		36BC17F01758BCD200567951 /* Extract libxml2 sources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/src/libxml2-${LIBXML2_VERSION}.tar.gz",
+			);
+			name = "Extract libxml2 sources";
+			outputPaths = (
+				"${PROJECT_DIR}/src/libxml2-${LIBXML2_VERSION}",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src\"\n/usr/bin/tar xzf \"libxml2-${LIBXML2_VERSION}.tar.gz\"";
+		};
+		36BC17F21758D7D300567951 /* Copy Executables & libraries, Fix dylib paths */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Executables & libraries, Fix dylib paths";
+			outputPaths = (
+				$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/bin/psql,
+				$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/lib/libpq.dylib,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "EXECUTABLE_TARGET_DIR=\"$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH\"\n\n# copy binaries\ncd \"${PROJECT_DIR}/Postgres/Vendor/postgres/bin/\"\nmkdir -p \"$EXECUTABLE_TARGET_DIR/bin/\"\ncp clusterdb createdb createlang createuser dropdb droplang dropuser ecpg initdb oid2name pg_archivecleanup pg_basebackup pg_config pg_controldata pg_ctl pg_dump pg_dumpall pg_receivexlog pg_resetxlog pg_restore pg_standby pg_test_fsync pg_test_timing pg_upgrade pgbench postgres postmaster psql reindexdb vacuumdb vacuumlo \"$EXECUTABLE_TARGET_DIR/bin/\"\n\n# copy dynamic libraries only (no need for static libraries)\ncd \"${PROJECT_DIR}/Postgres/Vendor/postgres/lib/\"\nmkdir -p \"$EXECUTABLE_TARGET_DIR/lib/\"\ncp -af *.dylib *.so \"$EXECUTABLE_TARGET_DIR/lib/\"\n\n# fix dylib paths\ncd \"$EXECUTABLE_TARGET_DIR\"\nprefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\"\nprefix_length=${#prefix}\n    \n# fix library ids\nfor libfile in lib/*\ndo\n    library_id=$(otool -D $libfile | grep \"$prefix\");\n    if [[ -n \"$library_id\" ]]\n    then\n        new_library_id=\"@loader_path/..\"${library_id:$prefix_length}\n        install_name_tool -id \"$new_library_id\" \"$libfile\"\n    fi\ndone\n                       \n# fix library references\nfor file in lib/* bin/*\ndo\n    linked_libs=$(otool -L $file | egrep --only-matching \"\\Q$prefix\\E\\S+\");\n    for lib_path in $linked_libs\n    do\n        new_lib_path=\"@loader_path/..\"${lib_path:$prefix_length}\n        install_name_tool -change \"$lib_path\" \"$new_lib_path\" $file\n    done\ndone";
+		};
+		36E814B01757971D00A993BF /* Download postgres */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Download postgres";
+			outputPaths = (
+				"${PROJECT_DIR}/src/postgresql-${POSTGRES_VERSION}.tar.bz2",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\nmkdir -p \"${PROJECT_DIR}/src\"\ncd \"${PROJECT_DIR}/src\"\n/usr/bin/curl --silent --show-error --remote-name \"http://ftp.postgresql.org/pub/source/v${POSTGRES_VERSION}/postgresql-${POSTGRES_VERSION}.tar.bz2\"";
+			showEnvVarsInLog = 0;
+		};
+		36E814B11757971F00A993BF /* Extract Sources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/src/postgresql-${POSTGRES_VERSION}.tar.bz2",
+			);
+			name = "Extract Sources";
+			outputPaths = (
+				"${PROJECT_DIR}/src/postgresql-${POSTGRES_VERSION}",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src\"\n/usr/bin/tar xzf \"postgresql-${POSTGRES_VERSION}.tar.bz2\"\n\n#we need to patch the postgresql source so ossp-uuid compiles on mountain lion\ncd \"postgresql-${POSTGRES_VERSION}/contrib/uuid-ossp\"\necho '#define _XOPEN_SOURCE' >uuid-ossp.c.patched\ncat uuid-ossp.c >>uuid-ossp.c.patched\nmv uuid-ossp.c.patched uuid-ossp.c";
+		};
+		36E814B217579EC800A993BF /* Download libxml2 */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Download libxml2";
+			outputPaths = (
+				"${PROJECT_DIR}/src/libxml2-${LIBXML2_VERSION}.tar.gz",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\nmkdir -p \"${PROJECT_DIR}/src\"\ncd \"${PROJECT_DIR}/src\"\n/usr/bin/curl --silent --show-error --remote-name \"ftp://xmlsoft.org/libxml2/libxml2-${LIBXML2_VERSION}.tar.gz\"";
+			showEnvVarsInLog = 0;
+		};
+		F802E6661730A785005EFEA5 /* Build libuuid */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/src/uuid-${LIBUUID_VERSION}",
+			);
+			name = "Build libuuid";
+			outputPaths = (
+				"${PROJECT_DIR}/Postgres/Vendor/postgres/include/uuid.h",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src/uuid-${LIBUUID_VERSION}\"\n./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" --disable-debug\n/usr/bin/make\n/usr/bin/make install";
+		};
+		F802E66D1730AB76005EFEA5 /* build libxml2 */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/src/libxml2-${LIBXML2_VERSION}",
+			);
+			name = "build libxml2";
+			outputPaths = (
+				"${PROJECT_DIR}/Postgres/Vendor/postgres/lib/libxml2.dylib",
+				"${PROJECT_DIR}/Postgres/Vendor/postgres/include/libxml2",
+				"${PROJECT_DIR}/Postgres/Vendor/postgres/bin/xml2-config",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src/libxml2-${LIBXML2_VERSION}\"\n# we have to redirect stderr so Xcode doesn't report unnecessary errors\n./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" --disable-dependency-tracking 2>configure.stderr\n# we want to make executables only, no documentation\n/usr/bin/make install-exec\n/usr/bin/make -C include install";
 		};
 		F802E6701730B1B5005EFEA5 /* Build & Install liblwgeom */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -955,19 +1209,21 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/bin/sh\n\nmkdir -p ${PROJECT_DIR}/src\ncd ${PROJECT_DIR}/src\n\n# $POSTGIS_VERSION defined in Build Settings\n\ncd \"postgis-${POSTGIS_VERSION}/liblwgeom\"\n\n/usr/bin/sed -i -e 's/\\/usr\\/local$/\\${PROJECT_DIR}\\/Postgres\\/Vendor\\/postgres\\//g' Makefile\n\n/usr/bin/make install\n";
 		};
-		F805351B15388B0A000E1BAC /* Download, Build, & Install postgres */ = {
+		F805351B15388B0A000E1BAC /* Build & Install postgres */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PROJECT_DIR}/src/postgresql-${POSTGRES_VERSION}",
 			);
-			name = "Download, Build, & Install postgres";
+			name = "Build & Install postgres";
 			outputPaths = (
+				"${PROJECT_DIR}/Postgres/Vendor/postgres/bin/psql",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n\nmkdir -p ${PROJECT_DIR}/src\ncd ${PROJECT_DIR}/src\n\n# $POSTGRES_VERSION defined in Build Settings\n/usr/bin/curl -O \"http://ftp.postgresql.org/pub/source/v${POSTGRES_VERSION}/postgresql-${POSTGRES_VERSION}.tar.bz2\"\n/usr/bin/tar xzf \"postgresql-${POSTGRES_VERSION}.tar.bz2\"\ncd \"postgresql-${POSTGRES_VERSION}\"\n\n# the --with-includes and --with-libraries options are necessary so that postgres will be compiled and linked against\n# our own versions of libraries like openssl, instead of the system provided ones\nsh ./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" --with-includes=\"${PROJECT_DIR}/Postgres/Vendor/postgres/include\" --with-libraries=\"${PROJECT_DIR}/Postgres/Vendor/postgres/lib\" --enable-thread-safety --without-docdir --with-openssl --with-gssapi --with-bonjour --with-krb5 --with-libxml --with-libxslt --with-perl --with-python\n/usr/bin/make install-world\n";
+			shellPath = /bin/bash;
+			shellScript = "set -e\ncd \"${PROJECT_DIR}/src/postgresql-${POSTGRES_VERSION}\"\n#this is to make sure we find the right xml2-config\nexport PATH=\"${PROJECT_DIR}/Postgres/Vendor/postgres/bin:$PATH\"\n# the --with-includes and --with-libraries options are necessary so\n# that postgres will be compiled and linked against our own versions\n# of libraries like openssl, instead of system provided versions\nsh ./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" --with-includes=\"${PROJECT_DIR}/Postgres/Vendor/postgres/include\" --with-libraries=\"${PROJECT_DIR}/Postgres/Vendor/postgres/lib\" --enable-thread-safety --with-openssl --with-gssapi --with-bonjour --with-krb5 --with-libxml --with-libxslt --with-perl --with-python --with-libedit-preferred --with-ossp-uuid\n/usr/bin/make install-world\n\ntouch ${PROJECT_DIR}/Postgres/Vendor/postgres/bin/psql";
 		};
 		F805351C15388B2A000E1BAC /* Download, Build, & Install geos */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1011,19 +1267,20 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/bin/sh\n\nmkdir -p ${PROJECT_DIR}/src\ncd ${PROJECT_DIR}/src\n\n# $POSTGIS_VERSION defined in Build Settings\n\n/usr/bin/curl -L10 -O \"http://postgis.org/download/postgis-${POSTGIS_VERSION}.tar.gz\"\n/usr/bin/tar xzf \"postgis-${POSTGIS_VERSION}.tar.gz\"\ncd \"postgis-${POSTGIS_VERSION}\"\n\nexport PATH=\"${PROJECT_DIR}/Postgres/Vendor/postgres/bin/:${PATH}\"\n\nsh ./autogen.sh\nsh ./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" --with-pgconfig=\"${PROJECT_DIR}/Postgres/Vendor/postgres/bin/pg_config\" --with-geosconfig=\"${PROJECT_DIR}/Postgres/Vendor/postgres/bin/geos-config\" --with-projdir=\"${PROJECT_DIR}/Postgres/Vendor/postgres\" --with-gdaldir=\"${PROJECT_DIR}/Postgres/Vendor/postgres\"\n\n/usr/bin/make\n/usr/bin/make install\n";
 		};
-		F8273EF5156AC7C200199DA0 /* Download, Build, & Install libedit */ = {
+		F8273EF5156AC7C200199DA0 /* Download libedit */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Download, Build, & Install libedit";
+			name = "Download libedit";
 			outputPaths = (
+				"${PROJECT_DIR}/src/libedit-${LIBEDIT_VERSION}.tar.gz",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n\nmkdir -p ${PROJECT_DIR}/src\ncd ${PROJECT_DIR}/src\n\n# $LIBEDIT_VERSION defined in Build Settings\n\n/usr/bin/curl -L10 -O \"http://www.thrysoee.dk/editline/libedit-${LIBEDIT_VERSION}.tar.gz\"\n/usr/bin/tar xzf \"libedit-${LIBEDIT_VERSION}.tar.gz\"\n\ncd \"libedit-${LIBEDIT_VERSION}\"\n\nsh ./configure --prefix=\"${PROJECT_DIR}/Postgres/Vendor/postgres\"\n/usr/bin/make install\n";
+			shellPath = /bin/bash;
+			shellScript = "set -e\nmkdir -p \"${PROJECT_DIR}/src\"\ncd \"${PROJECT_DIR}/src\"\n# $LIBEDIT_VERSION defined in Build Settings\n/usr/bin/curl -L10 --silent --show-error --remote-name \"http://www.thrysoee.dk/editline/libedit-${LIBEDIT_VERSION}.tar.gz\"";
 		};
 		F8273F56156C131400199DA0 /* Download, Build, & Install libjasper */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1079,7 +1336,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n\nexport LC_RPATH=\"@executable_path\"\n\ndirectories=( \"bin\" \"lib\" )\nfor directory in ${directories[@]}\ndo\n  cd \"${PROJECT_DIR}/Postgres/Vendor/postgres/${directory}\"\n  for file in *\n  do\n    # openssl libraries are installed read-only, so make sure we can write to them\n    chmod u+w $file\n\n    basename=`basename $file`\n    if [[ $file == *.dylib ]]\n    then\n      /usr/bin/install_name_tool -id \"/Applications/Postgres.app/Contents/MacOS/lib/${basename}\" $file\n    fi\n\n    libs=( \"libpq.5.dylib\" \"libproj.0.dylib\" \"libgdal.dylib\" \"libgdal.1.dylib\" \"libgeos_c.1.dylib\" \"libgeos-3.3.5.dylib\" \"libv8.dylib\" \"libecpg.6.dylib\" \"libecpg_compat.3.dylib\" \"libedit.0.dylib\" \"libpgtypes.3.dylib\" \"libjasper.1.dylib\" \"libjpeg.8.dylib\" \"libssl.1.0.0.dylib\" \"libcrypto.1.0.0.dylib\" \"libuuid.16.dylib\" \"libxml2.dylib\" )\n    for lib in ${libs[@]}\n    do\n      /usr/bin/install_name_tool -add_rpath \"@rpath/lib/${lib}\" $file\n      /usr/bin/install_name_tool -change \"${PROJECT_DIR}/Postgres/Vendor/postgres/lib/${lib}\" \"@executable_path/../lib/${lib}\" $file\n    done\n\n    /usr/bin/install_name_tool -change \"/usr/lib/libedit.3.dylib\" \"@executable_path/../lib/libedit.3.dylib\" $file\n    /usr/bin/install_name_tool -change \"/usr/local/lib/liblwgeom-2.0.0.dylib\" \"@executable_path/../lib/liblwgeom-2.0.0.dylib\" $file\n    /usr/bin/install_name_tool -change \"/usr/local/lib/libjasper.1.0.0.dylib\" \"@executable_path/../lib/libjasper.1.0.0.dylib\" $file\n    /usr/bin/install_name_tool -change \"/usr/local/lib/libjpeg.8.dylib\" \"@executable_path/../lib/libjpeg.8.dylib\" $file\n  done\ndone\n";
+			shellScript = "#!/bin/sh\n\nexport LC_RPATH=\"@executable_path\"\n\ndirectories=( \"bin\" \"lib\" )\nfor directory in ${directories[@]}\ndo\n  cd \"${PROJECT_DIR}/Postgres/Vendor/postgres/${directory}\"\n  for file in *\n  do\n    # openssl libraries are installed read-only, so make sure we can write to them\n    chmod u+w $file\n\n    basename=`basename $file`\n    if [[ $file == *.dylib ]]\n    then\n      /usr/bin/install_name_tool -id \"/Applications/Postgres.app/Contents/MacOS/lib/${basename}\" $file\n    fi\n\n    libs=( \"libpq.5.dylib\" \"libproj.0.dylib\" \"libgdal.dylib\" \"libgdal.1.dylib\" \"libgeos_c.1.dylib\" \"libgeos-3.3.5.dylib\" \"libv8.dylib\" \"libecpg.6.dylib\" \"libecpg_compat.3.dylib\" \"libedit.0.dylib\" \"libpgtypes.3.dylib\" \"libjasper.1.dylib\" \"libjpeg.8.dylib\" \"libssl.1.0.0.dylib\" \"libcrypto.1.0.0.dylib\" \"libuuid.16.dylib\" \"libxml2.dylib\" )\n    for lib in ${libs[@]}\n    do\n      /usr/bin/install_name_tool -add_rpath \"@rpath/lib/${lib}\" $file\n      /usr/bin/install_name_tool -change \"${PROJECT_DIR}/Postgres/Vendor/postgres/lib/${lib}\" \"@loader_path/../lib/${lib}\" $file\n    done\n\n    /usr/bin/install_name_tool -change \"/usr/lib/libedit.3.dylib\" \"@loader_path/../lib/libedit.3.dylib\" $file\n    /usr/bin/install_name_tool -change \"/usr/local/lib/liblwgeom-2.0.0.dylib\" \"@loader_path/../lib/liblwgeom-2.0.0.dylib\" $file\n    /usr/bin/install_name_tool -change \"/usr/local/lib/libjasper.1.0.0.dylib\" \"@loader_path/../lib/libjasper.1.0.0.dylib\" $file\n    /usr/bin/install_name_tool -change \"/usr/local/lib/libjpeg.8.dylib\" \"@loader_path/../lib/libjpeg.8.dylib\" $file\n  done\ndone\n";
 		};
 		F8BE0C6D15A4C61400139A21 /* Download, Build, and Install libjpeg */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1174,10 +1431,30 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		36AEBA961721582D003B4CB9 /* PBXTargetDependency */ = {
+		367FC5AE1758885B00BD53A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 3609051B172147B6002FBC53 /* openssl */;
-			targetProxy = 36AEBA951721582D003B4CB9 /* PBXContainerItemProxy */;
+			target = F8273EF0156AC7B900199DA0 /* libedit */;
+			targetProxy = 367FC5AD1758885B00BD53A9 /* PBXContainerItemProxy */;
+		};
+		369B33661757906300FD18FE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 369B335E1757816A00FD18FE /* openssl */;
+			targetProxy = 369B33651757906300FD18FE /* PBXContainerItemProxy */;
+		};
+		36BC17EF1758AEDC00567951 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F802E6621730A780005EFEA5 /* libuuid */;
+			targetProxy = 36BC17EE1758AEDC00567951 /* PBXContainerItemProxy */;
+		};
+		36BC17F41758D93C00567951 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F805350315388AE4000E1BAC /* postgresql */;
+			targetProxy = 36BC17F31758D93C00567951 /* PBXContainerItemProxy */;
+		};
+		36E814B51757A12E00A993BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F802E6691730AB6D005EFEA5 /* libxml2 */;
+			targetProxy = 36E814B41757A12E00A993BF /* PBXContainerItemProxy */;
 		};
 		F802E6681730AACB005EFEA5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1332,19 +1609,64 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		3609051C172147B6002FBC53 /* Debug */ = {
+		364C865B1758E1F20088CA7A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				OPENSSL_VERSION = 1.0.1e;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEBUGGING_SYMBOLS = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
-		3609051D172147B6002FBC53 /* Release */ = {
+		364C865C1758E1F20088CA7A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		369B33611757816A00FD18FE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				OPENSSL_VERSION = 1.0.1e;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "openssl copy";
+			};
+			name = Debug;
+		};
+		369B33621757816A00FD18FE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OPENSSL_VERSION = 1.0.1e;
+				PRODUCT_NAME = "openssl copy";
 			};
 			name = Release;
 		};
@@ -1808,11 +2130,20 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		3609051E172147B6002FBC53 /* Build configuration list for PBXAggregateTarget "openssl" */ = {
+		364C865A1758E1F20088CA7A /* Build configuration list for PBXLegacyTarget "postgr" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3609051C172147B6002FBC53 /* Debug */,
-				3609051D172147B6002FBC53 /* Release */,
+				364C865B1758E1F20088CA7A /* Debug */,
+				364C865C1758E1F20088CA7A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		369B33601757816A00FD18FE /* Build configuration list for PBXAggregateTarget "openssl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				369B33611757816A00FD18FE /* Debug */,
+				369B33621757816A00FD18FE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/README.md
+++ b/README.md
@@ -14,16 +14,23 @@ Documentation is available at [http://postgresapp.com/documentation](http://post
 
 ## What's Included?
 
-- [PostgreSQL 9.1.3](http://www.postgresql.org/docs/9.1/static/release-9-1-3.html)
-- [PostGIS 2.0](http://postgis.refractions.net/)
+- [PostgreSQL 9.2.4](http://www.postgresql.org/docs/9.1/static/release-9-1-3.html)
+- [PostGIS 2.0.1](http://postgis.refractions.net/)
 - [plv8](http://code.google.com/p/plv8js/wiki/PLV8)
 
 ## How To Build
 
+The XCode project is set up so it automatically downloads and builds the PostgreSQL source code (and other required software packages)
+
+To build Postgres.app with PostgreSQL only:
 1. Open `Postgres.xcodeproj` in Xcode
-2. Select the "Postgres Binaries" scheme, and build by clicking "Run", or using the keyboard shortcut, `⌘B`.
-3. Optionally, Select the "Postgres Extensions" scheme, and build in the same manner.
-3. Once the binaries are finished building, select the "Postgres Mac Application" scheme, and build & run by clicking "Run", or using the keyboard shortcut, `⌘R`.
+2. Select the `Postgres` scheme, and click "Run"
+
+To build Postgres.app with extensions (PostGIS, v8):
+1. Open `Postgres.xcodeproj` in Xcode
+2. Select `postgres-binaries` scheme, and build using the keyboard shortcut ⌘B
+3. Select `postgres-extensions`, build
+4. Select `Postgres`, click run
 
 ## Under the Hood
 


### PR DESCRIPTION
- changed gdal build script to avoid an error related to config.rpath
- added two configure parameters for gdal so it finds and links to the right libpq and finds libjasper
- changed the lib jasper download location to the one provided by gdal. They use a modified version, see http://trac.osgeo.org/gdal/wiki/JasPer for details (thanks to @kashif)
