### PR TITLE
Fix dark mode (and compile error)

### DIFF
--- a/Postgres/Server.swift
+++ b/Postgres/Server.swift
@@ -312,7 +312,7 @@ class Server: NSObject {
 		listenAddress.sin_addr.s_addr = inet_addr("127.0.0.1")
 		
 		let bindRes = withUnsafePointer(to: &listenAddress) { (sockaddrPointer: UnsafePointer<sockaddr_in>) in
-			sockaddrPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { (sockaddrPointer2: UnsafeMutablePointer<sockaddr>) in
+			sockaddrPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer2 in
 				Darwin.bind(sock, sockaddrPointer2, socklen_t(MemoryLayout<sockaddr_in>.stride))
 			}
 		}

--- a/PostgresMenuHelper/AppDelegate.swift
+++ b/PostgresMenuHelper/AppDelegate.swift
@@ -31,8 +31,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 		statusItem.menu = statusMenu
 		statusItem.image = templateOffImage
 		statusItem.alternateImage = templateOnImage
-        templateOffImage.isTemplate = isDarkMode
-        templateOnImage.isTemplate = isDarkMode
+		templateOffImage.isTemplate = isDarkMode
+		templateOnImage.isTemplate = isDarkMode
 		
 		DistributedNotificationCenter.default().addObserver(forName: Notification.Name("AppleInterfaceThemeChangedNotification"), object: nil, queue: OperationQueue.main) { _ in
 			self.templateOffImage.isTemplate = self.isDarkMode

--- a/PostgresMenuHelper/AppDelegate.swift
+++ b/PostgresMenuHelper/AppDelegate.swift
@@ -31,6 +31,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 		statusItem.menu = statusMenu
 		statusItem.image = templateOffImage
 		statusItem.alternateImage = templateOnImage
+        templateOffImage.isTemplate = isDarkMode
+        templateOnImage.isTemplate = isDarkMode
 		
 		DistributedNotificationCenter.default().addObserver(forName: Notification.Name("AppleInterfaceThemeChangedNotification"), object: nil, queue: OperationQueue.main) { _ in
 			self.templateOffImage.isTemplate = self.isDarkMode


### PR DESCRIPTION
Make sure template mode is set on the menu bar icons when the app is launched in dark mode. Also fixed a compile error.