### PR TITLE
Provide username when restoring db

### DIFF
--- a/docs/documentation/migrating-data.md
+++ b/docs/documentation/migrating-data.md
@@ -18,7 +18,7 @@ This is the easiest way to migrate your data.
 	`pg_dumpall --quote-all-identifiers | gzip >postgresapp.sql.gz`
 1.  Quit the old version of Postgres.app, then start the new version of Postgres.app
 1.	Now restore the SQL dump:<br>
-	`gunzip <postgresapp.sql.gz | psql`
+	`gunzip <postgresapp.sql.gz | psql -U postgres`
 
 ### Migrate data using `pg_dump`
 


### PR DESCRIPTION
Otherwise you get a “psql: FATAL:  role “<username>” does not exist”.
At least when going from 9.3 to 9.6