### PR TITLE
Fix double 'Stop' button

### DIFF
--- a/Postgres/ValueTransformers.swift
+++ b/Postgres/ValueTransformers.swift
@@ -42,12 +42,24 @@ class ServerStatusButtonTitleTransformer: ValueTransformer {
 		switch status {
 		case .DataDirEmpty:
 			return "Initialize"
-		case .Running:
-			return "Stop"
 		default:
 			return "Start"
 		}
 	}
+}
+
+class ServerStatusMenuItemButtonTitleTransformer: ValueTransformer {
+    override func transformedValue(_ value: Any?) -> Any? {
+        guard let intStatus = value as? Int, let status = Server.ServerStatus(rawValue: intStatus) else { return nil }
+        switch status {
+        case .DataDirEmpty:
+            return "Initialize"
+        case .Running:
+            return "Stop"
+        default:
+            return "Start"
+        }
+    }
 }
 
 class ServerStatusStatusMessageTransformer: ValueTransformer {

--- a/Postgres/ValueTransformers.swift
+++ b/Postgres/ValueTransformers.swift
@@ -49,17 +49,17 @@ class ServerStatusButtonTitleTransformer: ValueTransformer {
 }
 
 class ServerStatusMenuItemButtonTitleTransformer: ValueTransformer {
-    override func transformedValue(_ value: Any?) -> Any? {
-        guard let intStatus = value as? Int, let status = Server.ServerStatus(rawValue: intStatus) else { return nil }
-        switch status {
-        case .DataDirEmpty:
-            return "Initialize"
-        case .Running:
-            return "Stop"
-        default:
-            return "Start"
-        }
-    }
+	override func transformedValue(_ value: Any?) -> Any? {
+		guard let intStatus = value as? Int, let status = Server.ServerStatus(rawValue: intStatus) else { return nil }
+		switch status {
+		case .DataDirEmpty:
+			return "Initialize"
+		case .Running:
+			return "Stop"
+		default:
+			return "Start"
+		}
+	}
 }
 
 class ServerStatusStatusMessageTransformer: ValueTransformer {

--- a/PostgresMenuHelper/MenuItemView.xib
+++ b/PostgresMenuHelper/MenuItemView.xib
@@ -158,7 +158,7 @@
                                 </binding>
                                 <binding destination="-2" name="title" keyPath="server.serverStatus" id="vah-Fz-9bW">
                                     <dictionary key="options">
-                                        <string key="NSValueTransformerName">PostgresMenuHelper.ServerStatusButtonTitleTransformer</string>
+                                        <string key="NSValueTransformerName">PostgresMenuHelper.ServerStatusMenuItemButtonTitleTransformer</string>
                                     </dictionary>
                                 </binding>
                             </connections>


### PR DESCRIPTION
When a server is running, the main window start/stop/initialize buttons look like this:
![screen shot 2016-12-11 at 16 44 59](https://cloud.githubusercontent.com/assets/4563968/21080892/fe61d134-bfd3-11e6-8a3a-d6c1d6786776.png)
Which is kind of ugly, IMO.
This pull request makes it look like this:
![screen shot 2016-12-11 at 16 44 40](https://cloud.githubusercontent.com/assets/4563968/21080895/0377b008-bfd4-11e6-9b02-f3293e42b915.png)
