### PR TITLE
Update Server.swift initdb to pass --data-checksums

### DIFF
--- a/Postgres/Server.swift
+++ b/Postgres/Server.swift
@@ -435,6 +435,7 @@ class Server: NSObject {
 		process.arguments = [
 			"-D", varPath,
 			"-U", "postgres",
+			"--data-checksums",
 			"--encoding=UTF-8",
 			"--locale=en_US.UTF-8"
 		]


### PR DESCRIPTION
Pass --data-checksums to the initdb

According to doc: https://www.postgresql.org/docs/9.6/static/app-initdb.html

"--data-checksums
Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent. Enabling checksums may incur a noticeable performance penalty. This option can only be set during initialization, and cannot be changed later. If set, checksums are calculated for all objects, in all databases."