### PR TITLE
Add Metabase to the list of Postgres Mac GUI Apps

### DIFF
--- a/docs/de/documentation/gui-tools.md
+++ b/docs/de/documentation/gui-tools.md
@@ -17,6 +17,7 @@ Hier sind Links zu allen Mac-Clients die ich finden konnte (in alphabetischer Re
 - [DBGlass](http://dbglass.web-pal.com)
 - [DbVisualizer](https://www.dbvis.com/)
 - [Froq](https://www.colourful-apps.com/products/mac/froq)
+- [Metabase](https://metabase.com/start/mac.html)
 - [Navicat for PostgreSQL](http://www.navicat.com/products/navicat-for-postgresql)
 - [pgAdmin](http://pgadmin.org/)
 - [PostgreSQL Manager](https://itunes.apple.com/at/app/postgresql-manager/id875191518?mt=12)

--- a/docs/documentation/gui-tools.md
+++ b/docs/documentation/gui-tools.md
@@ -16,6 +16,7 @@ Here's a list of all the Mac Apps I found (in alphabetic order):
 - [DBGlass](http://dbglass.web-pal.com)
 - [DbVisualizer](https://www.dbvis.com/)
 - [Froq](https://www.colourful-apps.com/products/mac/froq)
+- [Metabase](https://metabase.com/start/mac.html)
 - [Navicat for PostgreSQL](http://www.navicat.com/products/navicat-for-postgresql)
 - [pgAdmin](http://pgadmin.org/)
 - [PostgreSQL Manager](https://itunes.apple.com/at/app/postgresql-manager/id875191518?mt=12)


### PR DESCRIPTION
[Metabase](https://github.com/metabase/metabase) is an open-source tool for connecting to databases and visualizing the results. I'm one of the maintainers of the project and would love it if you could add a link to it in the list of apps