### PR TITLE
Fix typo in "Stale postmaster.pid" error message

### DIFF
--- a/Postgres/Server.swift
+++ b/Postgres/Server.swift
@@ -191,7 +191,7 @@ class Server: NSObject {
 			case .StalePidFile:
 				let userInfo = [
 					NSLocalizedDescriptionKey: NSLocalizedString("The data directory contains an old postmaster.pid file", comment: ""),
-					NSLocalizedRecoverySuggestionErrorKey: "The data directory contains a postmaster.pid file, which usually means that the server is already running. When the server crashes or is killed, you have to remove this file before you can restart the server. Make sure that the database process is definitely not runnnig anymore, otherwise your data directory will be corrupted."
+					NSLocalizedRecoverySuggestionErrorKey: "The data directory contains a postmaster.pid file, which usually means that the server is already running. When the server crashes or is killed, you have to remove this file before you can restart the server. Make sure that the database process is definitely not running anymore, otherwise your data directory will be corrupted."
 				]
 				statusResult = .Failure(NSError(domain: "com.postgresapp.Postgres2.server-status", code: 0, userInfo: userInfo))
 				


### PR DESCRIPTION
Fixes a small typo ("runnnig" > "running") in the error message that
gets displayed when attempting to start the server when a
`postmaster.pid` file already exists.