### PR TITLE
Mojave AppleScript Permissions check

### DIFF
--- a/Postgres/Info.plist
+++ b/Postgres/Info.plist
@@ -42,5 +42,7 @@
 	<string>https://postgresapp.com/sparkle/updates.xml</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
Add a check to determine if MenuHelper has permissions to control Postgres.app (needed since macOS 10.14 Mojave)