### PR TITLE
Propose to add Ultorg to the list of GUI Client Apps

### DIFF
--- a/docs/documentation/gui-tools.md
+++ b/docs/documentation/gui-tools.md
@@ -21,6 +21,7 @@ There are many clients for PostgreSQL on the Mac. Below is a list of some of the
 - [PSequel](http://www.psequel.com)
 - [SQLPro for PostgreSQL](http://www.hankinsoft.com/SQLProPostgres/)
 - [TablePlus](https://tableplus.io)
+- [Ultorg](https://www.ultorg.com) (visual query system)
 - [Valentina Studio](http://www.valentina-db.com/en/valentina-studio-overview)
 
 You can find many more of them on the [PostgreSQL Clients](https://wiki.postgresql.org/wiki/PostgreSQL_Clients) page in the PostgreSQL wiki. Some of them are quite powerful; some are still a bit rough.


### PR DESCRIPTION
This edit proposes to add Ultorg, a just-released graphical tool for working with SQL databases, to the "GUI Client Apps" list.

I have inserted the bullet in the alphabetical position.

(I am the founder of Ultorg. The system is a productization of an earlier academic project; it lets users create arbitrary database queries from a spreadsheet-like direct manipulation environment, without actually typing any SQL.)