### PR TITLE
Automatically delete stale postmaster.pid files

### DIFF
--- a/BUILD_HISTORY.md
+++ b/BUILD_HISTORY.md
@@ -9,6 +9,7 @@ This file documents recent and upcoming builds of Postgres.app.
 
 Version | Build | Release Date | Included PG Versions                        | PostGIS Versions                                | Notes
 --------|-------|--------------|---------------------------------------------|-------------------------------------------------|-------
+ 2.7.8a |  280  |  2024-11-08  | 17.0                                        | 3.5.0beta1                                      | Test build for #784
 2.8alpha|  279  |  2024-10-22  | 17.0                                        | 3.5.0beta1                                      | Test build for #776
  2.7.8  |  278  |  2024-09-26  | 12.20, 13.16, 14.13, 15.8, 16.4, 17.0       | 3.0.11, 3.1.11, 3.2.7, 3.3.7, 3.4.3, 3.5.0beta1 |
  2.7.8  |  277  |  2024-09-26  | 17.0                                        | 3.5.0beta1                                      |

--- a/Postgres/ValueTransformers.swift
+++ b/Postgres/ValueTransformers.swift
@@ -72,10 +72,6 @@ class ServerStatusStatusMessageTransformer: ValueTransformer {
 			return "Empty data directory"
 		case .DataDirInUse:
 			return "Data directory in use"
-		case .StalePidFile:
-			return "Stale postmaster.pid file"
-		case .PidFileUnreadable:
-			return "Unreadable postmaster.pid file"
 		case .PortInUse:
 			return "Port in use"
 		case .Startable:

--- a/docs/de/documentation/troubleshooting.md
+++ b/docs/de/documentation/troubleshooting.md
@@ -36,13 +36,18 @@ Dieser Fehler kann auftreten, wenn deine Data Directory von einer anderen Postgr
 Dazu musst du den anderen Server stoppen, bevor du Postgres.app öffnest.
 Es ist nicht empfehlenswert, eine Data Directory einer anderen PostgreSQL zu verwenden, da diese anders konfiguriert sein kann und dies zu weiteren Fehlern führen kann.
 
-#### The data directory contains an old postmaster.pid file / The data directory contains an unreadable postmaster.pid file
-PostgreSQL erstellt eine Datei namens `postmaster.pid` im Data Directory. Diese Datei enthält die aktuelle Prozess-ID des PostgreSQL Servers.
-Wenn der Server unerwartet beendet wird, kann diese Datei noch die ID des abgestürzten Prozesses enthalten, was dann zu diesem Fehler führt.
-In diesem Fall musst du die Datei `postmaster.pid` löschen bevor du den Server startest; stelle aber sicher dass der Server nicht läuft!
-Öffne dazu die Aktivitätsanzeige und stelle sicher, dass keine Prozesse namens ‘postgres‘ oder ‘postmaster‘ laufen.
+#### Could not delete stale postmaster.pid file
 
-Achtung: Wenn du die Datei `postmaster.pid` löschst während der Server läuft, können unangenehme Dinge passieren!
+PostgreSQL erstellt eine Datei namens `postmaster.pid` im Data Directory. Diese Datei enthält die aktuelle Prozess-ID des PostgreSQL Servers.
+Wenn der Server unerwartet beendet wird, kann diese Datei noch die PID des abgestürzten Prozesses enthalten.
+
+Postgres.app versucht in diesem Fall die Datei `postmaster.pid` zu löschen. Wenn dabei ein Fehler auftritt, kannst du versuchen die Datei manuell zu löschen.
+
+#### The data directory contains an old postmaster.pid file / The data directory contains an unreadable postmaster.pid file
+
+Frühere Versionen von Postgres.app zeigten diese Warnung, wenn das Data-Directory eine veraltete `postmaster.pid`-Datei enthält.
+
+Um dieses Problem zu beheben kannst du entweder die neueste Version von Postgres.app installieren; oder du kannst die `postmaster.pid` Datei einfach löschen.
 
 #### Could not initialize database cluster
 Dieser Fehler bedeutet, dass der Befehl `initdb` nicht erfolgreich war. Dies sollte im Normalfall nicht passieren; wenn doch, eröffne ein neues Issue auf Github.

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -52,14 +52,22 @@ This can happen if you've configured Postgres.app to use a data directory that i
 Stop the other server before starting Postgres.app.
 In general, it is not recommended to just use a data directory created by another version of PostgreSQL, since it might have been configured differently.
 
+#### Could not delete stale postmaster.pid file
+
+To keep track of the PostgreSQL server process, PostgreSQL stores the process id for the server in a file named `postmaster.pid` in the server's data directory.
+If PostgreSQL crashes, this file can contain an old pid that prevents PostgreSQL from starting.
+
+Postgres.app detects this problem and tries to automatically delete this stale `postmaster.pid` file if necessary.
+
+If you see the error message "Could not delete stale postmaster.pid file", then Postgres.app for some reason failed to delete this file.
+
+You may be able to fix the problem by deleting the file manually.
+
 #### The data directory contains an old postmaster.pid file / The data directory contains an unreadable postmaster.pid file
-PostgreSQL puts a file named `postmaster.pid` in the data directory to store the process id of the PostgreSQL server process.
-If PostgreSQL crashes, this file can contain an old pid that confuses PostgreSQL.
-You can fix this issue by deleting the `postmaster.pid` file. However, you must make sure that PostgreSQL is really not running.
-Open Activity Monitor and make sure that there are no processes named 'postgres' or 'postmaster'.
 
-If you delete the `postmaster.pid` file while PostgreSQL is running, bad things will happen.
+Previous versions of Postgres.app showed this error when the data directory contains a stale postmaster.pid file.
 
+To fix this problem, you can either upgrade to the latest version of Postgres.app; or you can manually delete the file `postmaster.pid` in the data directory.
 
 #### Could not initialize database cluster
 This error means that the `initdb` command failed.


### PR DESCRIPTION
There is really no reason that Postgres.app users should have to deal with postmaster.pid files!

This PR implements the proposal discussed in #573