### PR TITLE
Reindex all databases

### DIFF
--- a/docs/documentation/reindex-warning.md
+++ b/docs/documentation/reindex-warning.md
@@ -20,6 +20,9 @@ Rebuilding indexes is very simple:
 3. If you are using multiple databases, repeat the steps for every database.
 4. If Postgres.app shows the reindex warning, you can now hide it by clicking "More Info" and then on "Hide this Warning"
 
+Rebuilding indexes for all databases is even simpler:
+
+1. Run `reindex --all` from the command line
 
 Why should I reindex my databases?
 -----------------------------------------


### PR DESCRIPTION
The docs suggest to reindex all databases one by one, which is tedious for a non-trivial amount of databases. I feel like the documentation should also point out the `reindex --all` command, which makes this a trivial job.