### PR TITLE
Allow PostgresApp to manage servers w/Homebrew binaries

### DIFF
--- a/Postgres/BinaryManager.swift
+++ b/Postgres/BinaryManager.swift
@@ -11,49 +11,92 @@ import Foundation
 class BinaryManager {
 	static let shared = BinaryManager()
 	
-	let binaryVersionsURL = Bundle.main.bundleURL.appendingPathComponent("Contents/Versions", isDirectory: true)
+	let bundledBinaryVersionsURL = Bundle.main.bundleURL.appendingPathComponent("Contents/Versions", isDirectory: true)
+    let brewBinaryVersionsURL = URL(fileURLWithPath: "/opt/homebrew/Cellar")
 	
-	func findAvailableBinaries() -> [PostgresBinary] {
-		let binaryVersionsEnumerator = FileManager().enumerator(
-			at: binaryVersionsURL,
-			includingPropertiesForKeys: [.isDirectoryKey],
-			options: [.skipsSubdirectoryDescendants, .skipsPackageDescendants, .skipsHiddenFiles]
-		)!
-		var versions = [PostgresBinary]()
-		while let itemURL = binaryVersionsEnumerator.nextObject() as? URL {
-			do {
-				let resourceValues = try itemURL.resourceValues(forKeys: [.isDirectoryKey])
-				guard resourceValues.isDirectory == true else { continue }
-			} catch { continue }
-			let folderName = itemURL.lastPathComponent
-			versions.append(
-				PostgresBinary(url: itemURL, version: folderName)
-			)
-		}
-		versions.sort { (a, b) -> Bool in
-			return a.version.compare(b.version, options:[.numeric]) == .orderedAscending
-		}
-		return versions
+    func findAvailableBinaries() -> [PostgresBinary] {
+        var versions: [PostgresBinary] = []
+        versions.append(contentsOf: self.findAvailableBundledBinaries())
+        versions.append(contentsOf: self.findAvailableBrewBinaries())
+        return versions
+    }
+    
+	func findAvailableBundledBinaries() -> [PostgresBinary] {
+        return findAvailableBinaries(at: bundledBinaryVersionsURL)
 	}
+    
+    func findAvailableBrewBinaries() -> [PostgresBinary] {
+        guard let binaryVersionsEnumerator = FileManager().enumerator(
+            at: brewBinaryVersionsURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsSubdirectoryDescendants, .skipsPackageDescendants, .skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        var versions = [PostgresBinary]()
+        while let itemURL = binaryVersionsEnumerator.nextObject() as? URL {
+            do {
+                let resourceValues = try itemURL.resourceValues(forKeys: [.isDirectoryKey])
+                guard resourceValues.isDirectory == true else { continue }
+            } catch { continue }
+            guard itemURL.lastPathComponent.hasPrefix("postgresql@") else {
+                continue
+            }
+            versions.append(contentsOf: findAvailableBinaries(at: itemURL).map { binary in
+                var copy = binary
+                copy.displayName = "PostgreSQL Brew \(binary.version)"
+                return copy
+            })
+        }
+        return versions
+    }
+    
+    private func findAvailableBinaries(at: URL) -> [PostgresBinary] {
+        let binaryVersionsEnumerator = FileManager().enumerator(
+            at: at,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsSubdirectoryDescendants, .skipsPackageDescendants, .skipsHiddenFiles]
+        )!
+        var versions = [PostgresBinary]()
+        while let itemURL = binaryVersionsEnumerator.nextObject() as? URL {
+            do {
+                let resourceValues = try itemURL.resourceValues(forKeys: [.isDirectoryKey])
+                guard resourceValues.isDirectory == true else { continue }
+            } catch { continue }
+            let folderName = itemURL.lastPathComponent
+            versions.append(
+                PostgresBinary(url: itemURL, version: folderName)
+            )
+        }
+        versions.sort { (a, b) -> Bool in
+            return a.version.compare(b.version, options:[.numeric]) == .orderedAscending
+        }
+        return versions
+    }
 	
 	func getLatestBinary() -> PostgresBinary? {
 		let latestVersion = Bundle.main.object(forInfoDictionaryKey: "LatestStablePostgresVersion") as? String
 		guard let latestVersion, !latestVersion.isEmpty else { return nil }
-		return PostgresBinary(url: binaryVersionsURL.appendingPathComponent(latestVersion), version: latestVersion)
+        return PostgresBinary(url: bundledBinaryVersionsURL.appendingPathComponent(latestVersion), version: latestVersion)
 	}
 	
 	func getBinary(for version: String) -> PostgresBinary {
-		return PostgresBinary(url: binaryVersionsURL.appendingPathComponent(version), version: version)
+		return PostgresBinary(url: bundledBinaryVersionsURL.appendingPathComponent(version), version: version)
 	}
 }
 
 struct PostgresBinary {
-	var url: URL
+    var url: URL
 	var version: String
 	var binPath: String {
 		url.appendingPathComponent("bin").path
 	}
-	var displayName: String {
-		"PostgreSQL \(version)"
-	}
+    var displayName: String
+	
+    
+    init(url: URL, version: String, displayName: String? = nil) {
+        self.url = url
+        self.version = version
+        self.displayName = displayName ?? "PostgreSQL \(version)"
+    }
 }


### PR DESCRIPTION
PostgresApp is a fantastic way to manage Postgres on macOS however only being allowed to use the built-in binaries can be limiting:

1. Some users may have custom builds of Postgres with their own extensions or modifications
2. No access to pgxnclient to install extra extensions
3. The PostgresApp team having to pick and choose / maintain build scripts for which versions and tech goes into the bundled versions.

For us the magic of PostgresApp is how it manages the data directory, starting and stopping and permissions. We'd actually *prefer* to install postgres elsewhere for extension support.

This PR is somewhat rudimentary but scans the `/opt/homebrew/Cellar` folder for installed versions of Postgres and allows creating servers off of that.

Perhaps this is too "magic" and it would be best if PostgresApp allowed adding custom binary paths when creating a server instead?