### PR TITLE
Dynamic Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ At the very least, you need the following:
 
 - Xcode
 - Developer Tools (install with `xcode-select --install`)
-- Python from [python.org](https://www.python.org/downloads/macos/) in version 3.8.x (PostgreSQL 13), 3.9.x (PostgreSQL 14), 3.11.x (PostgreSQL 15), 3.12.x (PostgreSQL 16) or 3.13.x (PostgreSQL 17)
+- Python from [python.org](https://www.python.org/downloads/macos/) in version 3.8.x (PostgreSQL 13), 3.9.x (PostgreSQL 14), 3.11.x (PostgreSQL 15), 3.12.x (PostgreSQL 16), 3.13.x (PostgreSQL 17) or >=3.9.x (PostgreSQL >=18)
 
 For building PostGIS and its dependencies, you also need
 

--- a/docs/de/documentation/plpython.md
+++ b/docs/de/documentation/plpython.md
@@ -15,8 +15,9 @@ Allerdings ist Python 3 selbst nicht im Lieferumfang von Postgres.app --
 wenn du Python 3 verwenden willst, musst du es zusätzlich installieren.
 
 1. Lade und installiere Python 3.8.x für PostgreSQL 13, Python 3.9.x (universal2) für
-   PostgreSQL 14, Python 3.11.x für PostgreSQL 15, Python 3.12.x für PostgreSQL 16
-   und/oder Python 3.13.x für PostgreSQL 17 von
+   PostgreSQL 14, Python 3.11.x für PostgreSQL 15, Python 3.12.x für PostgreSQL 16,
+   Python 3.13.x für PostgreSQL 17 und/oder eine beliebige Version neuer oder gleich
+   Python 3.9.x (universal2) für PostgreSQL 18 von
    [python.org](https://www.python.org/downloads/macos/). 
    Andere Versionen von Python oder Pakete aus anderen Quellen werden nicht unterstützt.
 

--- a/docs/documentation/plpython.md
+++ b/docs/documentation/plpython.md
@@ -13,7 +13,7 @@ The default user created by Postgres.app is a superuser, so this shouldn't be an
 
 To use PL/Python with Postgres.app, you first need to install Python using the [installers from python.org](https://www.python.org/downloads/macos/).
 
-Unfortunately, PostgreSQL can only link with a specific version of Python.
+Unfortunately, PostgreSQL can only link with a specific version of Python until PostgreSQL 18.
 Please install the correct version of Python, depending on the PostgreSQL version you are using:
 
 <style>
@@ -30,11 +30,22 @@ Please install the correct version of Python, depending on the PostgreSQL versio
 
 | PostgreSQL Version | Python Version                                                           |
 | ------------------ | ------------------------------------------------------------------------ |
+| PostgreSQL 18      | Python >= 3.9.x from [python.org](https://www.python.org/downloads/macos/) |
 | PostgreSQL 17      | Python 3.13.x from [python.org](https://www.python.org/downloads/macos/) |
 | PostgreSQL 16      | Python 3.12.x from [python.org](https://www.python.org/downloads/macos/) |
 | PostgreSQL 15      | Python 3.11.x from [python.org](https://www.python.org/downloads/macos/) |
 | PostgreSQL 14      | Python 3.9.x from [python.org](https://www.python.org/downloads/macos/)  |
 | PostgreSQL 13      | Python 3.8.x from [python.org](https://www.python.org/downloads/macos/)  |
 | PostgreSQL 12 and earlier | Python 2.7 (included with macOS)                                  |
+
+PostgreSQL 18 supports linking with any Python version >= 3.2 loaded from `/Library/Frameworks/Python.framework`.
+The packages from python.org provide symlinks at this location since version 3.9. These point to another symlink,
+`/Library/Frameworks/Python.framework/Versions/Current`, which can be changed to the preferred Python version with
+something like `sudo ln -svih 3.12 /Library/Frameworks/Python.framework/Versions/Current` after the corresponding
+package has been installed. 
+
+Installing or linking `Python.framework`s to `/Library/Frameworks/` from other sources like homebrew
+should work as well, but is not tested nor supported:
+`sudo ln -s /opt/homebrew/Frameworks/Python.framework /Library/Frameworks/`
 
 Make sure to install the correct version of Python, then use the SQL command `CREATE EXTENSION plpython3u;` to enable the extension.

--- a/src-devel/makefile
+++ b/src-devel/makefile
@@ -11,8 +11,9 @@ POSTGIS_MAJOR_VERSION=3
 #POSTGRES_GIT_URL=https://github.com/postgres/postgres.git
 #POSTGRES_GIT_URL=https://github.com/postgresql-cfbot/postgresql.git
 
-POSTGRES_GIT_REF=HEAD
-POSTGRES_GIT_URL=https://github.com/postgres/postgres.git
+# 'Use Python "Limited API" in PL/Python' https://commitfest.postgresql.org/patch/5416
+POSTGRES_GIT_REF=cf/5416
+POSTGRES_GIT_URL=https://github.com/postgresql-cfbot/postgresql.git
 
 ifeq ($(POSTGRES_GIT_HASH),)
     POSTGRES_GIT_HASH:=$(shell cat POSTGRES_GIT_HASH 2>/dev/null)
@@ -158,7 +159,6 @@ ICU_MINOR_VERSION=1
 
 # https://www.python.org/downloads/macos/
 PYTHON_VERSION=3.13
-PYTHON_VERSION_FULL=3.13.2
 
 #path configuration
 BUILD_PREFIX=$(shell pwd)/build
@@ -228,6 +228,10 @@ postgresql: $(PREFIX)/bin/psql
 
 $(PREFIX)/bin/psql: postgresql-$(POSTGRES_VERSION)/GNUmakefile
 	MAKELEVEL=0 make -C "postgresql-$(POSTGRES_VERSION)" $(POSTGRES_TARGET) XMLINCLUDE=--catalogs
+	install_name_tool -change /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/Python /Library/Frameworks/Python.framework/Python $(PREFIX)/lib/postgresql/plpython3.dylib
+	install_name_tool -change /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/Python /Library/Frameworks/Python.framework/Python $(PREFIX)/lib/postgresql/hstore_plpython3.dylib
+	install_name_tool -change /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/Python /Library/Frameworks/Python.framework/Python $(PREFIX)/lib/postgresql/jsonb_plpython3.dylib
+	install_name_tool -change /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/Python /Library/Frameworks/Python.framework/Python $(PREFIX)/lib/postgresql/ltree_plpython3.dylib
 
 # setting PATH is to make sure we find the right xml2-config
 # the --with-includes and --with-libraries options are necessary so
@@ -1233,4 +1237,4 @@ check-rpath:
 
 check-python:
 # This checks if the specified python version is installed and is universal
-	$(PYTHON) -V | grep -q $(PYTHON_VERSION_FULL) && lipo $(PYTHON) -verify_arch arm64 x86_64
+	$(PYTHON) -V | grep -q $(PYTHON_VERSION) && lipo $(PYTHON) -verify_arch arm64 x86_64

--- a/src-devel/makefile
+++ b/src-devel/makefile
@@ -11,9 +11,8 @@ POSTGIS_MAJOR_VERSION=3
 #POSTGRES_GIT_URL=https://github.com/postgres/postgres.git
 #POSTGRES_GIT_URL=https://github.com/postgresql-cfbot/postgresql.git
 
-# 'Use Python "Limited API" in PL/Python' https://commitfest.postgresql.org/patch/5416
-POSTGRES_GIT_REF=cf/5416
-POSTGRES_GIT_URL=https://github.com/postgresql-cfbot/postgresql.git
+POSTGRES_GIT_REF=HEAD
+POSTGRES_GIT_URL=https://github.com/postgres/postgres.git
 
 ifeq ($(POSTGRES_GIT_HASH),)
     POSTGRES_GIT_HASH:=$(shell cat POSTGRES_GIT_HASH 2>/dev/null)

--- a/src-devel/makefile
+++ b/src-devel/makefile
@@ -157,9 +157,6 @@ QUICKJS_VERSION=2024-01-13
 ICU_MAJOR_VERSION=75
 ICU_MINOR_VERSION=1
 
-# https://www.python.org/downloads/macos/
-PYTHON_VERSION=3.13
-
 #path configuration
 BUILD_PREFIX=$(shell pwd)/build
 PREFIX=/Applications/Postgres.app/Contents/Versions/$(POSTGRES_MAJOR_VERSION)
@@ -172,7 +169,7 @@ DEVELOPER_DIR=/Library/Developer/CommandLineTools
 export PREFIX PATH PKG_CONFIG_LIBDIR DEVELOPER_DIR
 
 #python config
-PYTHON=/Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/bin/python3
+PYTHON=/Library/Frameworks/Python.framework/Versions/Current/bin/python3
 export PYTHON
 
 #compiler options
@@ -228,10 +225,10 @@ postgresql: $(PREFIX)/bin/psql
 
 $(PREFIX)/bin/psql: postgresql-$(POSTGRES_VERSION)/GNUmakefile
 	MAKELEVEL=0 make -C "postgresql-$(POSTGRES_VERSION)" $(POSTGRES_TARGET) XMLINCLUDE=--catalogs
-	install_name_tool -change /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/Python /Library/Frameworks/Python.framework/Python $(PREFIX)/lib/postgresql/plpython3.dylib
-	install_name_tool -change /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/Python /Library/Frameworks/Python.framework/Python $(PREFIX)/lib/postgresql/hstore_plpython3.dylib
-	install_name_tool -change /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/Python /Library/Frameworks/Python.framework/Python $(PREFIX)/lib/postgresql/jsonb_plpython3.dylib
-	install_name_tool -change /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)/Python /Library/Frameworks/Python.framework/Python $(PREFIX)/lib/postgresql/ltree_plpython3.dylib
+	ORIGINAL_PYTHON_PATH=$$(otool -L $(PREFIX)/lib/postgresql/plpython3.dylib | grep -m 1 -o '/Library/Frameworks/Python.framework/Versions/.*/Python') && \
+	for PYLIB in $(PREFIX)/lib/postgresql/*plpython3.dylib; do \
+		install_name_tool -change $$ORIGINAL_PYTHON_PATH /Library/Frameworks/Python.framework/Python $$PYLIB; \
+	done
 
 # setting PATH is to make sure we find the right xml2-config
 # the --with-includes and --with-libraries options are necessary so
@@ -1236,5 +1233,5 @@ check-rpath:
 		-exec otool -L {} \;
 
 check-python:
-# This checks if the specified python version is installed and is universal
-	$(PYTHON) -V | grep -q $(PYTHON_VERSION) && lipo $(PYTHON) -verify_arch arm64 x86_64
+# This checks if the specified python is universal
+	lipo $(PYTHON) -verify_arch arm64 x86_64


### PR DESCRIPTION
This uses the Python "Limited API" patches from PostgreSQL [Commit Fest ID 5416](https://commitfest.postgresql.org/patch/5416) and integrates the necessary changes to remove the tight coupling of a PostgreSQL version to a specific version of the python.org Python packages.