### PR TITLE
Crash Log Collector

### DIFF
--- a/Postgres.xcodeproj/project.pbxproj
+++ b/Postgres.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		83FB57201D1B05F000A903A3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 83FB571F1D1B05F000A903A3 /* Assets.xcassets */; };
 		83FB57231D1B05F000A903A3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 83FB57211D1B05F000A903A3 /* Main.storyboard */; };
 		83FB573C1D1B18C900A903A3 /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FB573B1D1B18C900A903A3 /* MainWindow.swift */; };
+		D7A2F0242DF044AA00F28AD0 /* CrashLogCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A2F0232DF044AA00F28AD0 /* CrashLogCollector.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -192,6 +193,7 @@
 		83FB57221D1B05F000A903A3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		83FB57241D1B05F000A903A3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		83FB573B1D1B18C900A903A3 /* MainWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
+		D7A2F0232DF044AA00F28AD0 /* CrashLogCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogCollector.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -308,6 +310,7 @@
 			children = (
 				839A38271D88494A00E9591A /* main.swift */,
 				83FB571B1D1B05F000A903A3 /* AppDelegate.swift */,
+				D7A2F0232DF044AA00F28AD0 /* CrashLogCollector.swift */,
 				83FB573B1D1B18C900A903A3 /* MainWindow.swift */,
 				838B8D361D649CB30050EF03 /* MainWindowModel.swift */,
 				8353FBDF1D1D5E4C002F77E7 /* SplitView.swift */,
@@ -617,6 +620,7 @@
 				3634D7F62954BB2C005CE01C /* BinaryManager.swift in Sources */,
 				36447A62282568BA00F5BB7A /* InstallHistory.swift in Sources */,
 				36C9D0482CC69746006ABA02 /* ConnectionDialog.swift in Sources */,
+				D7A2F0242DF044AA00F28AD0 /* CrashLogCollector.swift in Sources */,
 				8348A1F11DB52E9A0039A024 /* ValueTransformers.swift in Sources */,
 				83969DBB1D369BD1005B9F1C /* ClientLauncher.swift in Sources */,
 				838B8D371D649CB30050EF03 /* MainWindowModel.swift in Sources */,

--- a/Postgres/AppDelegate.swift
+++ b/Postgres/AppDelegate.swift
@@ -32,6 +32,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SUUpdaterDelegate, NSAlertDe
 	}
 	
 	func applicationDidFinishLaunching(_ notification: Notification) {
+		CrashLogCollector.shared.scanInBackground()
 		let clientAppPath = UserDefaults.standard.string(forKey: "PreferredClientApplicationPath") ?? ""
 		if clientAppPath.isEmpty {
 			// Read the old setting, reverting to Terminal as default

--- a/Postgres/CrashLogCollector.swift
+++ b/Postgres/CrashLogCollector.swift
@@ -1,0 +1,161 @@
+//
+//  CrashLogCollector.swift
+//  Postgres
+//
+//  Created by dev on 04.06.25.
+//  Copyright © 2025 postgresapp. All rights reserved.
+//
+
+import Foundation
+import AppKit
+
+class CrashLogCollector: NSObject, URLSessionDataDelegate {
+	static var shared = CrashLogCollector()
+	
+	func scanInBackground() {
+		Task.detached {
+			do {
+				try self.scan()
+			}
+			catch {
+				print("Failed to scan for crash reports: \(error)")
+				return
+			}
+		}
+	}
+	var newCrashes = [(filename: String, crashReport: String)]()
+	var uploadErrors = [(filename: String, errorDescription: String)]()
+	private func scan() throws {
+		let fileManager = FileManager()
+		let diagnosticReportsURL = URL(fileURLWithPath: NSHomeDirectory()+"/Library/Logs/DiagnosticReports")
+		let urls = try fileManager.contentsOfDirectory(at: diagnosticReportsURL,
+													   includingPropertiesForKeys: [.isDirectoryKey],
+													   options: [])
+		var processedFiles = UserDefaults.standard.stringArray(forKey: "ProcessedCrashFiles") ?? []
+		for url in urls {
+			if let isDirectory = try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory, isDirectory == true { continue }
+			let filename = url.lastPathComponent
+			if processedFiles.contains(filename) { continue }
+			if filename.hasPrefix("Postgres") || filename.hasPrefix("postgres") || filename.hasPrefix("psql") {
+				do {
+					let crashReport = try String(contentsOf: url, encoding: .utf8)
+					if filename.hasPrefix("postgres") || filename.hasPrefix("psql") {
+						// check path to avoid reporting homebrew or enterprisedb crashes
+						if crashReport.range(of: ".app/Contents/Versions/") == nil && crashReport.range(of: ".app\\/Contents\\/Versions\\/") == nil {
+							// probably not from Postgres.app
+							processedFiles.append(filename)
+							UserDefaults.standard.setValue(processedFiles, forKey: "ProcessedCrashFiles")
+							continue
+						}
+					}
+					newCrashes.append((filename: filename, crashReport: crashReport))
+				}
+				catch {
+					print("Could not read crash report \(filename)")
+				}
+			}
+		}
+		print("Scanning for crash reports finished")
+		if !newCrashes.isEmpty {
+			let newCrashes = newCrashes
+			Task { @MainActor in
+				let alert = NSAlert()
+				alert.messageText = newCrashes.count==1 ? "New crash report found" : "\(newCrashes.count) new crash reports found"
+				alert.informativeText = "Postgres.app can automatically send crash reports to the maintainers. Crash reports contain anonymized data about application crashes and are essential for fixing problems in the app."
+				alert.addButton(withTitle: newCrashes.count==1 ? "Send Crash Report" : "Send Crash Reports")
+				alert.addButton(withTitle: "Ignore")
+				var mainWindow: NSWindow?
+				for window in NSApplication.shared.windows {
+					if window.windowController is MainWindowController {
+						mainWindow = window
+					}
+				}
+				guard let mainWindow else {
+					print("Found crashes but did not find main window")
+					return
+				}
+				alert.beginSheetModal(for: mainWindow) { response in
+					if response == .alertFirstButtonReturn {
+						// transmit crashes
+						for (filename, crashData) in newCrashes {
+							var request = URLRequest(url: URL(string: "https://crashreporting.postgresapp.com/upload")!)
+							request.httpMethod = "POST"
+							request.httpBody = crashData.data(using: .utf8)
+							let postTask = self.session.dataTask(with: request) { _, response, error in
+								if let error {
+									self.uploadFailed(filename: filename, errorDescription: "failed to transmit crash \(filename): \(error)")
+									return
+								}
+								if let httpResponse = response as? HTTPURLResponse {
+									if httpResponse.statusCode == 200 {
+										self.uploadFinished(filename: filename)
+									} else {
+										self.uploadFailed(filename: filename, errorDescription: "failed to transmit crash \(filename): HTTP \(httpResponse.statusCode)")
+									}
+								} else {
+									self.uploadFailed(filename: filename, errorDescription: "failed to transmit crash \(filename): Unexpected response: \(response?.className ?? "nil")")
+								}
+							}
+							postTask.resume()
+						}
+					} else {
+						var processedFiles = UserDefaults.standard.stringArray(forKey: "ProcessedCrashFiles") ?? []
+						for (name, _) in newCrashes {
+							processedFiles.append(name)
+						}
+						UserDefaults.standard.setValue(processedFiles, forKey: "ProcessedCrashFiles")
+					}
+				}
+			}
+		}
+	}
+	lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: .main)
+	func uploadFinished(filename: String) {
+		Task { @MainActor in
+			print("Transmitted crash \(filename)")
+			var processedFiles = UserDefaults.standard.stringArray(forKey: "ProcessedCrashFiles") ?? []
+			processedFiles.append(filename)
+			UserDefaults.standard.setValue(processedFiles, forKey: "ProcessedCrashFiles")
+			newCrashes.removeAll { $0.filename == filename }
+			if newCrashes.isEmpty { reportErrors() }
+		}
+	}
+	func uploadFailed(filename: String, errorDescription: String) {
+		Task { @MainActor in
+			print("Failed to transmit crash \(filename)")
+			uploadErrors.append((filename: filename, errorDescription: errorDescription))
+			newCrashes.removeAll { $0.filename == filename }
+			if newCrashes.isEmpty { reportErrors() }
+		}
+	}
+	@MainActor func reportErrors() {
+		if uploadErrors.isEmpty {
+			print("All crashes transmitted successfully")
+			return
+		}
+		let alert = NSAlert()
+		alert.messageText = uploadErrors.count == 1 ? "Could not send crash report" : "Could not send \(uploadErrors.count) crash reports"
+		var informativeText = ""
+		for (index, uploadError) in uploadErrors.enumerated() {
+			if index > 2 && uploadErrors.count > 4 {
+				informativeText += "(and \(uploadErrors.count-index) more errors)\n"
+				break
+			}
+			informativeText += uploadError.errorDescription
+			informativeText += "\n"
+		}
+		informativeText.removeLast()
+		alert.informativeText = informativeText
+		var mainWindow: NSWindow?
+		for window in NSApplication.shared.windows {
+			if window.windowController is MainWindowController {
+				mainWindow = window
+			}
+		}
+		guard let mainWindow else {
+			print("Tried to report errors but did not find main window:\n\(alert.informativeText)")
+			return
+		}
+		alert.beginSheetModal(for: mainWindow)
+	}
+}

--- a/crashreporting/crashreporting.py
+++ b/crashreporting/crashreporting.py
@@ -1,0 +1,18 @@
+import tornado.websocket
+import json
+import os
+import asyncio
+import asyncpg
+
+class CrashReporting(tornado.web.RequestHandler):
+
+	async def post(self, path):
+		
+		self.request.body
+		
+		await self.application.pg_pool.execute(
+			"INSERT INTO crash_reports_raw(data) VALUES($1);",
+			self.request.body
+		)
+		
+		self.finish(f"Crash Report Received!")

--- a/crashreporting/crashreporting.py
+++ b/crashreporting/crashreporting.py
@@ -6,13 +6,20 @@ import asyncpg
 
 class CrashReporting(tornado.web.RequestHandler):
 
-	async def post(self, path):
+	async def post(self):
 		
-		self.request.body
+		# crash reports should always be valid utf-8
+		# .crash files are text based
+		# .ips are json-based
+		crash_report = self.request.body.decode()
+		
+		# we can extract Postgres.app version from the user agent
+		user_agent = self.request.headers.get("User-Agent")
 		
 		await self.application.pg_pool.execute(
-			"INSERT INTO crash_reports_raw(data) VALUES($1);",
-			self.request.body
+			"INSERT INTO crash_reports(report, user_agent) VALUES($1, $2);",
+			crash_report,
+			user_agent
 		)
 		
 		self.finish(f"Crash Report Received!")

--- a/crashreporting/crashreporting.service
+++ b/crashreporting/crashreporting.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Postgres.app Crash Reporting Service
+After=network.target
+
+[Service]
+Type=simple
+User=crashreporting
+Group=crashreporting
+WorkingDirectory=/opt/crashreporting
+ExecStartPre=+/sbin/sysctl -w net.ipv4.ip_unprivileged_port_start=443
+ExecStart=/usr/bin/python3 -u /opt/crashreporting/main.py
+EnvironmentFile=/etc/crashreporting/environment
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/crashreporting/deploy.sh
+++ b/crashreporting/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/zsh
+
+rsync -a ./ root@crashreporting.postgresapp.com:/opt/crashreporting/
+
+ssh root@crashreporting.postgresapp.com systemctl restart crashreporting.service
+
+ssh root@crashreporting.postgresapp.com journalctl -u crashreporting -f

--- a/crashreporting/index.html
+++ b/crashreporting/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset=utf-8>
+	<title>Crash Reporting for Postgres.app</title>
+</head>
+<body>
+	<h1>Crash Reporting for Postgres.app</h1>
+	<p>This webservice receives crash reports for Postgres.app</p>
+</body>
+</html>

--- a/crashreporting/main.py
+++ b/crashreporting/main.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3 -u
+
+import asyncio
+import tornado.ioloop
+import tornado.web
+import os
+import ssl
+
+async def start_app():
+	global ssl_ctx
+	import crashreporting
+	app = tornado.web.Application([
+		(r"/upload", crashreporting.CrashReporting),
+		(r"/", IndexPage),
+	])
+	app.pg_pool = await asyncpg.create_pool(os.environ['POSTGRES_CONNECTION_URL'], min_size=1, max_size=5)
+	if os.environ.get('SERVER_MODE') == 'test':
+		app.listen(8080)
+	else:
+		port = os.environ.get('LISTEN_PORT', 443)
+		ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+		load_app_certificate()
+		app.listen(port, ssl_options=ssl_ctx)
+
+def load_app_certificate():
+	global ssl_ctx
+	print("Loading Certificate")
+	ssl_ctx.load_cert_chain(os.environ['SSL_CERT_FILE'], os.environ['SSL_KEY_FILE'])
+	
+	# Reload the certificate once a day
+	# certbot automatically renews certificates
+	asyncio.get_running_loop().call_later(86400, load_app_certificate)
+	
+class IndexPage(tornado.web.RequestHandler):
+	async def get(self):
+		self.render("index.html")
+
+if __name__ == "__main__":
+	loop = asyncio.new_event_loop()
+	asyncio.set_event_loop(loop)
+	loop.run_until_complete(start_app())
+	loop.run_forever()

--- a/crashreporting/main.py
+++ b/crashreporting/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3 -u
 
 import asyncio
+import asyncpg
 import tornado.ioloop
 import tornado.web
 import os

--- a/crashreporting/setup.txt
+++ b/crashreporting/setup.txt
@@ -1,0 +1,23 @@
+# Steps to execute on the server to set up the crash reporting web server
+apt update
+apt upgrade
+reboot
+apt install certbot
+certbot certonly --standalone -d crashreporting.postgresapp.com --register-unsafely-without-email
+chmod -R o+rx /etc/letsencrypt
+apt install python3-tornado
+apt install python3-asyncpg
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin crashreporting
+mkdir /opt/crashreporting
+sudo chown -R crashreporting:crashreporting /opt/crashreporting
+# - install python app into /opt/crashreporting
+mkdir /etc/crashreporting
+vi /etc/crashreporting/environment
+vi /etc/systemd/system/crashreporting.service
+sudo systemctl daemon-reload
+systemctl enable crashreporting
+apt install postgresql-16
+sudo -u postgres createuser crashreporting
+sudo -u postgres psql
+# configure pg_hba.conf and pg_ident.conf
+# set up database


### PR DESCRIPTION
This adds a crash log collector to Postgres.app

Every time the GUI is started, it starts scanning `~/Library/Logs/DiagnosticReports` for relevant crash reports. If it finds any, it shows a dialog like this: 

![Bildschirmfoto 2025-06-06 um 13 58 30](https://github.com/user-attachments/assets/0dd2f763-a464-470b-aae7-f398da32e95b)

When the user clicks "Send Crash Report", Postgres.app sends a copy of the crash report(s) to a webservice running on https://crashreporting.postgresapp.com 

Crash reports are stored in a PostgreSQL database for further analysis.

The feature is designed to collect as little information as possible:
- crash reports are anonymised by macOS (user name and private paths are stripped)
- we do not log IP adresses or other identifiers
- reports are only transmitted after asking the user for permission
- the source code of the crash reporting server is included in the repo for reference

I hope that users make use of this feature so that we can improve the reliability of Postgres.app