### PR TITLE
Add TableAi to GUI tools documentation

### DIFF
--- a/docs/documentation/gui-tools.md
+++ b/docs/documentation/gui-tools.md
@@ -19,6 +19,7 @@ There are many clients for PostgreSQL on the Mac. Below is a list of some of the
 - [Postico](https://eggerapps.at/postico/)
 - [PSequel](http://www.psequel.com)
 - [SQLPro for PostgreSQL](http://www.hankinsoft.com/SQLProPostgres/)
+- [TableAi](https://tableai.org)
 - [TablePlus](https://tableplus.io)
 - [Valentina Studio](http://www.valentina-db.com/en/valentina-studio-overview)
 


### PR DESCRIPTION
Adds TableAI to the GUI tools documentation as a native macOS PostgreSQL client. The goal is to provide PostgreSQL users with another actively maintained GUI option alongside the existing tools listed on this page.